### PR TITLE
Create mysqli instance in global namespace. 

### DIFF
--- a/src/FM/ElFinderPHP/Driver/ElFinderVolumeMySQL.php
+++ b/src/FM/ElFinderPHP/Driver/ElFinderVolumeMySQL.php
@@ -99,7 +99,7 @@ class ElFinderVolumeMySQL extends ElFinderVolumeDriver {
 		}
 		
 		
-		$this->db = new mysqli($this->options['host'], $this->options['user'], $this->options['pass'], $this->options['db'], $this->options['port'], $this->options['socket']);
+		$this->db = new \mysqli($this->options['host'], $this->options['user'], $this->options['pass'], $this->options['db'], $this->options['port'], $this->options['socket']);
 		if ($this->db->connect_error || @mysqli_connect_error()) {
 			return false;
 		}


### PR DESCRIPTION
"new mysqli" don't works in FM\ElFinderPHP\Driver namespace. It must be "new \mysqli".
