### PR TITLE
On some platforms (FreeBSD & Gentoo) proc_open() get wrong working dir if the fourth parameter $cwd not set or null

### DIFF
--- a/src/FM/ElFinderPHP/Driver/ElFinderVolumeDriver.php
+++ b/src/FM/ElFinderPHP/Driver/ElFinderVolumeDriver.php
@@ -3031,7 +3031,7 @@ abstract class ElFinderVolumeDriver {
 	 * @return int     exit code
 	 * @author Alexey Sukhotin
 	 **/
-	protected function procExec($command , array &$output = null, &$return_var = -1, array &$error_output = null) {
+	protected function procExec($command , array &$output = null, &$return_var = -1, array &$error_output = null, $path = null) {
 
 		$descriptorspec = array(
 			0 => array("pipe", "r"),  // stdin
@@ -3039,7 +3039,7 @@ abstract class ElFinderVolumeDriver {
 			2 => array("pipe", "w")   // stderr
 		);
 
-		$process = proc_open($command, $descriptorspec, $pipes, null, null);
+		$process = proc_open($command, $descriptorspec, $pipes, $path, null);
 
 		if (is_resource($process)) {
 

--- a/src/FM/ElFinderPHP/Driver/ElFinderVolumeLocalFileSystem.php
+++ b/src/FM/ElFinderPHP/Driver/ElFinderVolumeLocalFileSystem.php
@@ -676,12 +676,9 @@ class ElFinderVolumeLocalFileSystem extends ElFinderVolumeDriver {
 	 * @author Alexey Sukhotin
 	 **/
 	protected function _unpack($path, $arc) {
-		$cwd = getcwd();
 		$dir = $this->_dirname($path);
-		chdir($dir);
 		$cmd = $arc['cmd'].' '.$arc['argc'].' '.escapeshellarg($this->_basename($path));
-		$this->procExec($cmd, $o, $c);
-		chdir($cwd);
+		$this->procExec($cmd, $o, $c, $e = null, $dir);
 	}
 
 	/**
@@ -824,14 +821,10 @@ class ElFinderVolumeLocalFileSystem extends ElFinderVolumeDriver {
 	 * @author Alexey Sukhotin
 	 **/
 	protected function _archive($dir, $files, $name, $arc) {
-		$cwd = getcwd();
-		chdir($dir);
-		
 		$files = array_map('escapeshellarg', $files);
 		
 		$cmd = $arc['cmd'].' '.$arc['argc'].' '.escapeshellarg($name).' '.implode(' ', $files);
-		$this->procExec($cmd, $o, $c);
-		chdir($cwd);
+		$this->procExec($cmd, $o, $c, $e = null, $dir);
 
 		$path = $dir.DIRECTORY_SEPARATOR.$name;
 		return file_exists($path) ? $path : false;


### PR DESCRIPTION
On some platforms (FreeBSD & Gentoo) proc_open() get wrong working dir if the fourth parameter $cwd not set or null
