### PR TITLE
returning path when using 'info' command + provided GET query parameters

### DIFF
--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -51,22 +51,23 @@ class ElFinderConnector {
     /**
      * Execute elFinder command and output result
      *
+     * @param  array  $queryParameters GET query parameters.
      * @return void
      * @author Nicolas MURE
      **/
-    public function run() {
-        exit(json_encode($this->execute()));
+    public function run($queryParameters) {
+        exit(json_encode($this->execute($queryParameters)));
     }
 
     /**
      * Execute elFinder command and returns result
-     *
+     * @param  array  $queryParameters GET query parameters.
      * @return array
      * @author Dmitry (dio) Levashov
      **/
-    public function execute() {
+    public function execute($queryParameters) {
         $isPost = $_SERVER["REQUEST_METHOD"] == 'POST';
-        $src    = $_SERVER["REQUEST_METHOD"] == 'POST' ? $_POST : $_GET;
+        $src    = $_SERVER["REQUEST_METHOD"] == 'POST' ? $_POST : $queryParameters;
         if ($isPost && !$src && $rawPostData = @file_get_contents('php://input')) {
             // for support IE XDomainRequest()
             $parts = explode('&', $rawPostData);

--- a/src/Driver/ElFinderVolumeDriver.php
+++ b/src/Driver/ElFinderVolumeDriver.php
@@ -2175,6 +2175,9 @@ abstract class ElFinderVolumeDriver {
             if (empty($stat['phash'])) {
                 $stat['phash'] = $this->encode($this->_dirname($path));
             }
+            if (empty($stat['path'])) {
+                $stat['path'] = $this->_path($path);
+            }
         }
 
         // fix name if required


### PR DESCRIPTION
This PR adds a 'path' key containg file's path + name to returned array when using 'info' command.
It also allows to set GET query parameters (previously guessed from $_GET), to enable sub requests.

Related to [# 128](https://github.com/helios-ag/FMElfinderBundle/pull/128) on the bundle side.