### PR TITLE
Fixes broken file downloading

### DIFF
--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -141,6 +141,8 @@ class ElFinderConnector {
         }
 
         if (isset($data['pointer'])) {
+            // The output buffer might be dirty which causes broken file downloads. 
+            ob_end_clean(); 
             rewind($data['pointer']);
             fpassthru($data['pointer']);
             if (!empty($data['volume'])) {


### PR DESCRIPTION
Hey there,

I don't know if it's just me, but I've been experiencing broken downloads across all of my symfony based projects which depend on this great package. The uploading works fine, but when you try to download the file via the UI it's just broken. At first, I thought there was a problem with my code, but that doesn't seem to be the case. 

After some debugging and playing around with the code in the ``ElFinderConnector`` class, I ended up adding ``ob_end_clean`` to the ``output`` method which seems to have solved the problem. I have a feeling Symfony might be adding some extra bytes to the output buffer which is why the downloaded files are broken.

Regards,
Steve