### PR TITLE
Access to the encode/decode function From onPreExecute (1/2)

### DIFF
--- a/src/ElFinder.php
+++ b/src/ElFinder.php
@@ -404,6 +404,15 @@ class ElFinder {
     }
 
     /**
+     * Return array of volume
+     *
+     * @return array
+     */
+    public function getVolumes() {
+        return $this->volumes;
+    }
+
+    /**
      * Return root - file's owner (public func of volume())
      *
      * @param  string  file hash


### PR DESCRIPTION

Ah sorry, the 2 new function that i have provide recently can't be used in the onPreExecute Event.

So i had to entirely review the functionnality.

Now it is accessible on both onPreExecute & onPostExecute Event. AND it's much more easy to use.
As you don't have to provide the Request parameter in the method :P

issue : https://github.com/helios-ag/FMElfinderBundle/issues/174

part 2/2 : https://github.com/helios-ag/FMElfinderBundle/pull/176