### PR TITLE
Hotfix/feature

### DIFF
--- a/src/Driver/ElFinderVolumeDriver.php
+++ b/src/Driver/ElFinderVolumeDriver.php
@@ -442,7 +442,7 @@ abstract class ElFinderVolumeDriver {
         'mpeg'  => 'video/mpeg',
         'mpg'   => 'video/mpeg',
         'mov'   => 'video/quicktime',
-        'wm'    => 'video/x-ms-wmv',
+        'wmv'   => 'video/x-ms-wmv',
         'flv'   => 'video/x-flv',
         'mkv'   => 'video/x-matroska',
         'webm'  => 'video/webm',

--- a/src/Driver/ElFinderVolumeDriver.php
+++ b/src/Driver/ElFinderVolumeDriver.php
@@ -2572,6 +2572,7 @@ abstract class ElFinderVolumeDriver {
                 if (empty($stat['hidden'])) {
                     $name = $stat['name'];
                     if (!$this->copy($this->_joinPath($src, $name), $dst, $name)) {
+                        $this->clearcache();
                         $this->remove($dst, true); // fall back
                         return false;
                     }


### PR DESCRIPTION
Without a clearcache() the new directory is unknown. So the remove() function return an error.