### PR TITLE
fix detecting of `$stat['name']` by `$meta['filename']`

### DIFF
--- a/src/Driver/ElFinderVolumeFlysystem.php
+++ b/src/Driver/ElFinderVolumeFlysystem.php
@@ -216,9 +216,12 @@ class ElFinderVolumeFlysystem extends ElFinderVolumeDriver {
             return array();
         }
         $meta = $this->fs->getMetadata($path);
-        // Set item filename to `name` if exists
-        if (isset($meta['filename'])) {
+        // Set item filename.extension to `name` if exists
+        if (isset($meta['filename']) && isset($meta['extension'])) {
             $stat['name'] = $meta['filename'];
+            if ($meta['extension'] !== '') {
+                $stat['name'] .= '.' . $meta['extension'];
+            }
         }
         // Get timestamp/size
         $stat['ts'] = isset($meta['timestamp'])? $meta['timestamp'] : $this->fs->getTimestamp($path);


### PR DESCRIPTION
"$meta['filename']" does not include a file extension in many cases.

see: https://github.com/nao-pon/elfinder-flysystem-driver/commit/770e369b1c739ac84a574f32f34094d1a6c1228a

Fixes #44