### PR TITLE
Add FIleMode option to thumbnails

### DIFF
--- a/src/Driver/ElFinderVolumeDriver.php
+++ b/src/Driver/ElFinderVolumeDriver.php
@@ -3853,6 +3853,7 @@ abstract class ElFinderVolumeDriver {
 
         $this->fcloseCE($src, $path);
         fclose($trg);
+        @chmod($tmb, $this->options['fileMode']);
 
         $result = false;
 


### PR DESCRIPTION
Set thumbnails' permissions to those given in the fileMode option to grant same access to images and their thumbnail, preventing conflicts between users' rights if kept to default 0644.